### PR TITLE
Prevented resource leak in PanoViewer.Utils.joglUtils.readShaderSource() method

### DIFF
--- a/src/main/java/PanoViewer/Utils/joglUtils.java
+++ b/src/main/java/PanoViewer/Utils/joglUtils.java
@@ -53,6 +53,9 @@ public class joglUtils {
     for (int i = 0; i < lines.size(); i++) {
       program[i] = (String) lines.elementAt(i) + "\n";
     }
+
+    sc.close();
+    
     return program;
   }
 


### PR DESCRIPTION
### **Changes**

This PR fixes the following :-
-  Prevents resource leakage in the `PanoViewer.Utils.joglUtils.readShaderSource()` method by closing the scanner instance before returning to the caller.